### PR TITLE
ci: use go-version-file to match go.mod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version-file: './backend/go.mod'
       
       - name: Run go vet
         working-directory: ./backend


### PR DESCRIPTION
## Summary

Replace the hardcoded `go-version: '1.21'` in CI with `go-version-file: './backend/go.mod'` so the CI Go version always stays in sync with the project.

### Problem
CI was pinned to Go 1.21 while `go.mod` specifies Go 1.25.1, which caused a build failure after PR #30 was merged.

### Fix
One-line change: use `go-version-file` instead of `go-version` in the setup-go action.

Closes #34