### PR TITLE
fix: default to most recent year when current year has no data

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -157,7 +157,8 @@ async function init() {
         populateYearSelector(yearsData.years);
         
         const hasCurrentYear = yearsData.years.some(y => y.year === currentYear);
-        const defaultYear = hasCurrentYear ? currentYear : yearsData.years[0].year;
+        const sortedYears = [...yearsData.years].sort((a, b) => b.year - a.year);
+        const defaultYear = hasCurrentYear ? currentYear : sortedYears[0].year;
         
         document.getElementById('year-selector').value = defaultYear;
         


### PR DESCRIPTION
## Summary

When the current year (2026) has no book data, the app was falling back to the first entry from the unsorted API response (2022) instead of the most recent year with data (2025), causing the empty state to display.

### Fix
Sort years descending before picking the fallback, so the app always defaults to the latest year with data.

### Before
```
No books tracked yet for 2026. Start reading!
```

### After
App loads 2025 data (34 books) with stats, chart, and book list.

Closes #36