### PR TITLE
feat: add input validation to API endpoints

### DIFF
--- a/backend/internal/handlers/admin.go
+++ b/backend/internal/handlers/admin.go
@@ -118,8 +118,8 @@ func CreateBook(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if req.Title == "" || req.Author == "" {
-		http.Error(w, "Title and author are required", http.StatusBadRequest)
+	if errs := validateBookRequest(req, false); len(errs) > 0 {
+		writeValidationError(w, errs)
 		return
 	}
 
@@ -173,6 +173,11 @@ func UpdateBook(w http.ResponseWriter, r *http.Request) {
 	var req BookRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "Invalid request", http.StatusBadRequest)
+		return
+	}
+
+	if errs := validateBookRequest(req, true); len(errs) > 0 {
+		writeValidationError(w, errs)
 		return
 	}
 
@@ -297,6 +302,11 @@ func GetGoal(w http.ResponseWriter, r *http.Request) {
 	year, err := strconv.Atoi(path)
 	if err != nil {
 		http.Error(w, "Invalid year", http.StatusBadRequest)
+		return
+	}
+
+	if err := validateYear(year); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 

--- a/backend/internal/handlers/admin.go
+++ b/backend/internal/handlers/admin.go
@@ -306,7 +306,7 @@ func GetGoal(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := validateYear(year); err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		writeValidationError(w, []string{err.Error()})
 		return
 	}
 

--- a/backend/internal/handlers/admin.go
+++ b/backend/internal/handlers/admin.go
@@ -176,7 +176,7 @@ func UpdateBook(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if errs := validateBookRequest(req, true); len(errs) > 0 {
+	if errs := validateBookRequest(req, false); len(errs) > 0 {
 		writeValidationError(w, errs)
 		return
 	}

--- a/backend/internal/handlers/admin_test.go
+++ b/backend/internal/handlers/admin_test.go
@@ -695,6 +695,33 @@ func TestGetGoalInvalidYear(t *testing.T) {
 	}
 }
 
+// TestGetGoalOutOfRangeYear verifies JSON error for out-of-range year values
+func TestGetGoalOutOfRangeYear(t *testing.T) {
+	s := setupTestStore(t)
+	defer teardownTestStore(t, s)
+
+	for _, year := range []string{"1899", "2101"} {
+		t.Run("year="+year, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/goals/"+year, nil)
+			w := httptest.NewRecorder()
+
+			GetGoal(w, req)
+
+			if w.Code != http.StatusBadRequest {
+				t.Errorf("Expected status %d, got %d", http.StatusBadRequest, w.Code)
+			}
+
+			var resp map[string]interface{}
+			if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+				t.Fatalf("Expected JSON response, got: %s", w.Body.String())
+			}
+			if resp["error"] != "Validation failed" {
+				t.Errorf("Expected error 'Validation failed', got %v", resp["error"])
+			}
+		})
+	}
+}
+
 // TestGetGoalWrongMethod verifies error with wrong HTTP method
 func TestGetGoalWrongMethod(t *testing.T) {
 	// Create POST request instead of GET

--- a/backend/internal/handlers/admin_test.go
+++ b/backend/internal/handlers/admin_test.go
@@ -452,6 +452,81 @@ func TestUpdateBookWrongMethod(t *testing.T) {
 	}
 }
 
+// TestUpdateBookMissingRequiredFields verifies that PUT requires title and author
+func TestUpdateBookMissingRequiredFields(t *testing.T) {
+	s := setupTestStore(t)
+	defer teardownTestStore(t, s)
+
+	// Create a book so we have a valid ID
+	book := &store.Book{Title: "Original", Author: "Author", Shelf: "read"}
+	id, err := s.CreateBook(book)
+	if err != nil {
+		t.Fatalf("Failed to create book: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		body map[string]interface{}
+		want []string
+	}{
+		{
+			name: "missing title",
+			body: map[string]interface{}{"author": "Some Author"},
+			want: []string{"title is required"},
+		},
+		{
+			name: "missing author",
+			body: map[string]interface{}{"title": "Some Title"},
+			want: []string{"author is required"},
+		},
+		{
+			name: "missing both",
+			body: map[string]interface{}{},
+			want: []string{"title is required", "author is required"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			bodyBytes, _ := json.Marshal(tc.body)
+			idStr := fmt.Sprintf("%d", id)
+			req := httptest.NewRequest(http.MethodPut, "/api/books/"+idStr, bytes.NewBuffer(bodyBytes))
+			req.URL.Path = "/api/books/" + idStr
+			w := httptest.NewRecorder()
+
+			UpdateBook(w, req)
+
+			if w.Code != http.StatusBadRequest {
+				t.Errorf("Expected status %d, got %d", http.StatusBadRequest, w.Code)
+			}
+
+			var resp map[string]interface{}
+			if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+				t.Fatalf("Failed to decode response: %v", err)
+			}
+			if resp["error"] != "Validation failed" {
+				t.Errorf("Expected error 'Validation failed', got %v", resp["error"])
+			}
+			fields, ok := resp["fields"].([]interface{})
+			if !ok {
+				t.Fatalf("Expected fields to be a slice, got %T", resp["fields"])
+			}
+			for _, want := range tc.want {
+				found := false
+				for _, f := range fields {
+					if f.(string) == want {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("Expected field error %q in %v", want, fields)
+				}
+			}
+		})
+	}
+}
+
 // TestDeleteBook verifies deleting a book
 func TestDeleteBook(t *testing.T) {
 	// Setup test database

--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -103,7 +103,7 @@ func GetBooks(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := validateYear(year); err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		writeValidationError(w, []string{err.Error()})
 		return
 	}
 
@@ -206,7 +206,7 @@ func GetStats(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := validateYear(year); err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		writeValidationError(w, []string{err.Error()})
 		return
 	}
 	

--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -102,6 +102,11 @@ func GetBooks(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if err := validateYear(year); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
 	// Optional filters
 	shelfFilter := r.URL.Query().Get("shelf")
 	monthStr := r.URL.Query().Get("month")
@@ -197,6 +202,11 @@ func GetStats(w http.ResponseWriter, r *http.Request) {
 	year, err := strconv.Atoi(yearStr)
 	if err != nil {
 		http.Error(w, "invalid year parameter", http.StatusBadRequest)
+		return
+	}
+
+	if err := validateYear(year); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 	

--- a/backend/internal/handlers/handlers_test.go
+++ b/backend/internal/handlers/handlers_test.go
@@ -192,6 +192,32 @@ func TestGetBooksInvalidYear(t *testing.T) {
 	}
 }
 
+// TestGetBooksOutOfRangeYear verifies JSON error for out-of-range year values
+func TestGetBooksOutOfRangeYear(t *testing.T) {
+	SetBooks(setupTestBooks())
+
+	for _, year := range []string{"1899", "2101"} {
+		t.Run("year="+year, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/books?year="+year, nil)
+			w := httptest.NewRecorder()
+
+			GetBooks(w, req)
+
+			if w.Code != http.StatusBadRequest {
+				t.Errorf("Expected status %d, got %d", http.StatusBadRequest, w.Code)
+			}
+
+			var resp map[string]interface{}
+			if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+				t.Fatalf("Expected JSON response, got: %s", w.Body.String())
+			}
+			if resp["error"] != "Validation failed" {
+				t.Errorf("Expected error 'Validation failed', got %v", resp["error"])
+			}
+		})
+	}
+}
+
 // TestGetBooksWithShelfFilter verifies filtering by shelf
 func TestGetBooksWithShelfFilter(t *testing.T) {
 	// Setup
@@ -343,6 +369,32 @@ func TestGetStatsInvalidYear(t *testing.T) {
 	// Verify response code
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("Expected status %d, got %d", http.StatusBadRequest, w.Code)
+	}
+}
+
+// TestGetStatsOutOfRangeYear verifies JSON error for out-of-range year values
+func TestGetStatsOutOfRangeYear(t *testing.T) {
+	SetBooks(setupTestBooks())
+
+	for _, year := range []string{"1899", "2101"} {
+		t.Run("year="+year, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/stats?year="+year, nil)
+			w := httptest.NewRecorder()
+
+			GetStats(w, req)
+
+			if w.Code != http.StatusBadRequest {
+				t.Errorf("Expected status %d, got %d", http.StatusBadRequest, w.Code)
+			}
+
+			var resp map[string]interface{}
+			if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+				t.Fatalf("Expected JSON response, got: %s", w.Body.String())
+			}
+			if resp["error"] != "Validation failed" {
+				t.Errorf("Expected error 'Validation failed', got %v", resp["error"])
+			}
+		})
 	}
 }
 

--- a/backend/internal/handlers/validation.go
+++ b/backend/internal/handlers/validation.go
@@ -1,0 +1,81 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strings"
+)
+
+var (
+	isbnRegex    = regexp.MustCompile(`^\d{10}$|^\d{13}$`)
+	dateRegex    = regexp.MustCompile(`^\d{4}/\d{2}/\d{2}$`)
+	validShelves = map[string]bool{
+		"read":              true,
+		"currently-reading": true,
+		"to-read":           true,
+	}
+)
+
+// validateYear checks that a year is within a reasonable range.
+func validateYear(year int) error {
+	if year < 1900 || year > 2100 {
+		return fmt.Errorf("year must be between 1900 and 2100")
+	}
+	return nil
+}
+
+// validateBookRequest validates a book creation/update request and returns
+// a list of field-level error messages. If the list is empty, the request is valid.
+// When isUpdate is true, title and author are not required (partial updates).
+func validateBookRequest(req BookRequest, isUpdate bool) []string {
+	var errors []string
+
+	if !isUpdate {
+		if strings.TrimSpace(req.Title) == "" {
+			errors = append(errors, "title is required")
+		}
+		if strings.TrimSpace(req.Author) == "" {
+			errors = append(errors, "author is required")
+		}
+	}
+
+	if len(req.Title) > 500 {
+		errors = append(errors, "title must be 500 characters or less")
+	}
+	if len(req.Author) > 500 {
+		errors = append(errors, "author must be 500 characters or less")
+	}
+
+	if req.Pages < 0 {
+		errors = append(errors, "pages must be 0 or greater")
+	}
+
+	if req.ISBN != "" && !isbnRegex.MatchString(req.ISBN) {
+		errors = append(errors, "isbn must be 10 or 13 digits")
+	}
+	if req.ISBN13 != "" && !isbnRegex.MatchString(req.ISBN13) {
+		errors = append(errors, "isbn13 must be 10 or 13 digits")
+	}
+
+	if req.DateRead != "" && !dateRegex.MatchString(req.DateRead) {
+		errors = append(errors, "dateRead must be in YYYY/MM/DD format")
+	}
+
+	if req.Shelf != "" && !validShelves[req.Shelf] {
+		errors = append(errors, "shelf must be one of: read, currently-reading, to-read")
+	}
+
+	return errors
+}
+
+// writeValidationError writes a 400 response with a JSON body listing validation errors.
+func writeValidationError(w http.ResponseWriter, errors []string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusBadRequest)
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"error":  "Validation failed",
+		"fields": errors,
+	})
+}

--- a/backend/internal/handlers/validation_test.go
+++ b/backend/internal/handlers/validation_test.go
@@ -1,0 +1,200 @@
+package handlers
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateYear(t *testing.T) {
+	tests := []struct {
+		name    string
+		year    int
+		wantErr bool
+	}{
+		{"valid 2025", 2025, false},
+		{"valid 1900", 1900, false},
+		{"valid 2100", 2100, false},
+		{"too low", 1899, true},
+		{"too high", 2101, true},
+		{"zero", 0, true},
+		{"negative", -1, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateYear(tt.year)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateYear(%d) error = %v, wantErr %v", tt.year, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateBookRequest_Create(t *testing.T) {
+	tests := []struct {
+		name       string
+		req        BookRequest
+		wantErrors []string
+	}{
+		{
+			name: "valid minimal",
+			req:  BookRequest{Title: "Test Book", Author: "Test Author"},
+		},
+		{
+			name: "valid full",
+			req: BookRequest{
+				Title:    "Test Book",
+				Author:   "Test Author",
+				Pages:    200,
+				ISBN:     "1234567890",
+				DateRead: "2025/03/15",
+				Shelf:    "read",
+			},
+		},
+		{
+			name:       "missing title",
+			req:        BookRequest{Author: "Author"},
+			wantErrors: []string{"title is required"},
+		},
+		{
+			name:       "missing author",
+			req:        BookRequest{Title: "Title"},
+			wantErrors: []string{"author is required"},
+		},
+		{
+			name:       "missing both",
+			req:        BookRequest{},
+			wantErrors: []string{"title is required", "author is required"},
+		},
+		{
+			name:       "whitespace-only title",
+			req:        BookRequest{Title: "   ", Author: "Author"},
+			wantErrors: []string{"title is required"},
+		},
+		{
+			name:       "title too long",
+			req:        BookRequest{Title: strings.Repeat("a", 501), Author: "Author"},
+			wantErrors: []string{"title must be 500 characters or less"},
+		},
+		{
+			name:       "author too long",
+			req:        BookRequest{Title: "Title", Author: strings.Repeat("a", 501)},
+			wantErrors: []string{"author must be 500 characters or less"},
+		},
+		{
+			name:       "negative pages",
+			req:        BookRequest{Title: "Title", Author: "Author", Pages: -1},
+			wantErrors: []string{"pages must be 0 or greater"},
+		},
+		{
+			name: "zero pages valid",
+			req:  BookRequest{Title: "Title", Author: "Author", Pages: 0},
+		},
+		{
+			name:       "invalid ISBN too short",
+			req:        BookRequest{Title: "Title", Author: "Author", ISBN: "12345"},
+			wantErrors: []string{"isbn must be 10 or 13 digits"},
+		},
+		{
+			name:       "invalid ISBN with letters",
+			req:        BookRequest{Title: "Title", Author: "Author", ISBN: "123456789X"},
+			wantErrors: []string{"isbn must be 10 or 13 digits"},
+		},
+		{
+			name: "valid ISBN 10 digits",
+			req:  BookRequest{Title: "Title", Author: "Author", ISBN: "1234567890"},
+		},
+		{
+			name: "valid ISBN 13 digits",
+			req:  BookRequest{Title: "Title", Author: "Author", ISBN: "9781234567890"},
+		},
+		{
+			name:       "invalid dateRead format",
+			req:        BookRequest{Title: "Title", Author: "Author", DateRead: "2025-03-15"},
+			wantErrors: []string{"dateRead must be in YYYY/MM/DD format"},
+		},
+		{
+			name: "valid dateRead",
+			req:  BookRequest{Title: "Title", Author: "Author", DateRead: "2025/03/15"},
+		},
+		{
+			name: "empty dateRead valid",
+			req:  BookRequest{Title: "Title", Author: "Author", DateRead: ""},
+		},
+		{
+			name:       "invalid shelf",
+			req:        BookRequest{Title: "Title", Author: "Author", Shelf: "finished"},
+			wantErrors: []string{"shelf must be one of: read, currently-reading, to-read"},
+		},
+		{
+			name: "valid shelf read",
+			req:  BookRequest{Title: "Title", Author: "Author", Shelf: "read"},
+		},
+		{
+			name: "valid shelf currently-reading",
+			req:  BookRequest{Title: "Title", Author: "Author", Shelf: "currently-reading"},
+		},
+		{
+			name: "valid shelf to-read",
+			req:  BookRequest{Title: "Title", Author: "Author", Shelf: "to-read"},
+		},
+		{
+			name: "empty shelf valid",
+			req:  BookRequest{Title: "Title", Author: "Author", Shelf: ""},
+		},
+		{
+			name: "multiple errors",
+			req: BookRequest{
+				Title:    "",
+				Author:   "",
+				Pages:    -5,
+				ISBN:     "bad",
+				DateRead: "invalid",
+				Shelf:    "unknown",
+			},
+			wantErrors: []string{
+				"title is required",
+				"author is required",
+				"pages must be 0 or greater",
+				"isbn must be 10 or 13 digits",
+				"dateRead must be in YYYY/MM/DD format",
+				"shelf must be one of: read, currently-reading, to-read",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := validateBookRequest(tt.req, false)
+			if len(tt.wantErrors) == 0 {
+				if len(errs) != 0 {
+					t.Errorf("expected no errors, got %v", errs)
+				}
+				return
+			}
+			if len(errs) != len(tt.wantErrors) {
+				t.Errorf("expected %d errors, got %d: %v", len(tt.wantErrors), len(errs), errs)
+				return
+			}
+			for i, want := range tt.wantErrors {
+				if errs[i] != want {
+					t.Errorf("error[%d] = %q, want %q", i, errs[i], want)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateBookRequest_Update(t *testing.T) {
+	// For updates, title and author are not required
+	errs := validateBookRequest(BookRequest{}, true)
+	if len(errs) != 0 {
+		t.Errorf("update with empty fields should not require title/author, got %v", errs)
+	}
+
+	// But other validations still apply
+	errs = validateBookRequest(BookRequest{Pages: -1, ISBN: "bad"}, true)
+	if len(errs) != 2 {
+		t.Errorf("expected 2 errors for invalid pages and ISBN, got %d: %v", len(errs), errs)
+	}
+}


### PR DESCRIPTION
## Summary

Add comprehensive input validation to all API endpoints that accept user input.

### Validation Rules

**Year parameter** (GetBooks, GetStats, GetGoal):
- Must be between 1900-2100

**Book fields** (CreateBook, UpdateBook):
| Field | Rule |
|-------|------|
| `title` | Required on create, max 500 chars |
| `author` | Required on create, max 500 chars |
| `pages` | Must be ≥ 0 |
| `isbn`/`isbn13` | 10 or 13 digits if provided |
| `dateRead` | YYYY/MM/DD format if provided |
| `shelf` | Must be `read`, `currently-reading`, or `to-read` |

### Error Response Format
```json
{
  "error": "Validation failed",
  "fields": ["title is required", "pages must be 0 or greater"]
}
```

### Files
- **New**: `validation.go` — reusable validation helpers
- **New**: `validation_test.go` — 25+ test cases
- **Modified**: `handlers.go` — year range checks on GetBooks/GetStats
- **Modified**: `admin.go` — book validation on CreateBook/UpdateBook, year range on GetGoal

All tests pass ✅

Closes #10