### PR TITLE
feat: redesign metrics as individual stat cards with emojis

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -20,17 +20,27 @@
     </header>
 
     <main>
-        <!-- Stats bar - horizontal, full width -->
+        <!-- Stats bar - individual stat cards -->
         <section id="statistics" class="stats-bar">
-            <div class="summary-card">
-                <h2 class="summary-title">2025 Summary</h2>
-                <div class="stats-list">
-                    <!-- Stats populated by JavaScript -->
-                </div>
+            <div class="stat-card">
+                <span class="stat-emoji">📚</span>
+                <p class="stat-value" id="stat-books">0</p>
+                <h2>Books</h2>
             </div>
             <div class="stat-card">
-                <h2>Average per Month</h2>
+                <span class="stat-emoji">📄</span>
+                <p class="stat-value" id="stat-pages">0</p>
+                <h2>Pages</h2>
+            </div>
+            <div class="stat-card">
+                <span class="stat-emoji">📊</span>
+                <p class="stat-value" id="stat-avg-pages">0</p>
+                <h2>Avg Pages</h2>
+            </div>
+            <div class="stat-card">
+                <span class="stat-emoji">📅</span>
                 <p class="stat-value" id="avg-per-month">0.0</p>
+                <h2>Per Month</h2>
             </div>
             <span id="total-books" hidden>0</span>
             <span id="total-pages" hidden>0</span>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,7 +1,7 @@
 // Main application entry point
 import { fetchYears, fetchStats, fetchBooks, fetchGoal } from './api-client.js';
 import { renderChart } from './chart.js';
-import { populateYearSelector, updateStatistics, renderSummaryCard, showEmptyState, showError, showContent } from './ui.js';
+import { populateYearSelector, updateStatistics, renderStatCards, showEmptyState, showError, showContent } from './ui.js';
 
 let currentYear = new Date().getFullYear();
 
@@ -14,7 +14,7 @@ async function loadYearData(year) {
         ]);
         const goal = goalData?.target ?? null;
         
-        renderSummaryCard(stats);
+        renderStatCards(stats);
         
         if (stats.totalBooks === 0) {
             showEmptyState(year);

--- a/frontend/src/ui.js
+++ b/frontend/src/ui.js
@@ -27,47 +27,22 @@ export function formatNumber(num) {
     return num.toLocaleString('en-US');
 }
 
-// T010: Render summary card with reading statistics
-export function renderSummaryCard(stats) {
-    const summaryCard = document.querySelector('.summary-card');
-    if (!summaryCard) return;
+// T010: Render individual stat cards with reading statistics
+export function renderStatCards(stats) {
+    const booksEl = document.getElementById('stat-books');
+    const pagesEl = document.getElementById('stat-pages');
+    const avgPagesEl = document.getElementById('stat-avg-pages');
 
-    // Update title
-    const summaryTitle = summaryCard.querySelector('.summary-title');
-    if (summaryTitle) {
-        summaryTitle.textContent = `${stats.year} Summary`;
-    }
-
-    // Handle empty state (0 books)
     if (stats.totalBooks === 0) {
-        summaryCard.classList.add('empty-state');
-        summaryCard.querySelector('.stats-list').innerHTML = `
-            <p class="empty-message">No books tracked for this year</p>
-        `;
+        if (booksEl) booksEl.textContent = '0';
+        if (pagesEl) pagesEl.textContent = '0';
+        if (avgPagesEl) avgPagesEl.textContent = '0';
         return;
     }
 
-    // Remove empty state class if it exists
-    summaryCard.classList.remove('empty-state');
-
-    // Render stat rows
-    const statsList = summaryCard.querySelector('.stats-list');
-    if (statsList) {
-        statsList.innerHTML = `
-            <div class="stat-row">
-                <span class="stat-label">Total Books</span>
-                <span class="stat-value">${stats.totalBooks}</span>
-            </div>
-            <div class="stat-row">
-                <span class="stat-label">Total Pages</span>
-                <span class="stat-value">${formatNumber(stats.totalPages)}</span>
-            </div>
-            <div class="stat-row">
-                <span class="stat-label">Avg Pages/Book</span>
-                <span class="stat-value">${stats.averagePagesPerBook || Math.floor(stats.totalPages / stats.totalBooks)}</span>
-            </div>
-        `;
-    }
+    if (booksEl) booksEl.textContent = stats.totalBooks;
+    if (pagesEl) pagesEl.textContent = formatNumber(stats.totalPages);
+    if (avgPagesEl) avgPagesEl.textContent = stats.averagePagesPerBook || Math.floor(stats.totalPages / stats.totalBooks);
 }
 
 

--- a/frontend/styles/main.css
+++ b/frontend/styles/main.css
@@ -107,76 +107,47 @@ main {
     align-items: stretch;
 }
 
-.stats-bar .summary-card {
-    flex: 1.5;
-    min-width: 0;
-}
-
 .stats-bar .stat-card {
     flex: 1;
     min-width: 0;
 }
 
-/* Summary Card */
-.summary-card {
+/* Stats Cards */
+.stat-card {
     background: var(--color-surface);
     padding: 16px 20px;
     border-radius: var(--radius-md);
     border: 1px solid var(--color-border);
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 2px;
 }
 
-.summary-title {
+.stat-emoji {
+    font-size: 1.25rem;
+    line-height: 1;
+    margin-bottom: 2px;
+}
+
+.stat-card h2 {
     font-size: 0.7rem;
     font-weight: 600;
     color: var(--color-text-muted);
     text-transform: uppercase;
-    letter-spacing: 0.08em;
-    margin-bottom: 10px;
-    padding-bottom: 8px;
-    border-bottom: 1px solid var(--color-border-muted);
+    letter-spacing: 0.05em;
+    margin: 0;
 }
 
-.stats-list {
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
+.stat-card .stat-value {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: var(--color-accent);
+    letter-spacing: -0.02em;
+    margin: 0;
 }
-
-.stat-row {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-}
-
-.stat-label {
-    font-size: 0.8rem;
-    color: var(--color-text-secondary);
-}
-
-.stat-value {
-    font-size: 1.1rem;
-    font-weight: 600;
-    color: var(--color-text);
-}
-
-.summary-card.empty-state {
-    text-align: center;
-    padding: 20px 16px;
-}
-
-.empty-message {
-    font-size: 0.95rem;
-    color: var(--color-text-muted);
-}
-
-.empty-message::before {
-    content: "📚";
-    display: block;
-    font-size: 2.5rem;
-    margin-bottom: 12px;
-}
-
-/* Goal Progress */
 #goal-progress {
     background: var(--color-surface);
     padding: 16px 24px;
@@ -224,34 +195,6 @@ main {
     color: var(--color-text-muted);
     margin-top: 10px;
     text-align: right;
-}
-
-/* Stats Cards */
-.stat-card {
-    background: var(--color-surface);
-    padding: 16px 20px;
-    border-radius: var(--radius-md);
-    border: 1px solid var(--color-border);
-    text-align: center;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-}
-
-.stat-card h2 {
-    font-size: 0.7rem;
-    font-weight: 600;
-    color: var(--color-text-muted);
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    margin-bottom: 4px;
-}
-
-.stat-card .stat-value {
-    font-size: 1.5rem;
-    font-weight: 700;
-    color: var(--color-accent);
-    letter-spacing: -0.02em;
 }
 
 /* Chart Container */
@@ -473,12 +416,8 @@ main {
         gap: 8px;
     }
 
-    .stats-bar .summary-card {
-        flex-basis: 100%;
-    }
-
     .stats-bar .stat-card {
-        flex: 1;
+        flex: 1 1 calc(50% - 4px);
         min-width: 0;
     }
     

--- a/frontend/tests/ui.test.js
+++ b/frontend/tests/ui.test.js
@@ -6,21 +6,25 @@ describe('Dashboard Layout Tests', () => {
     document.body.innerHTML = `
       <main>
         <section id="statistics" class="stats-bar">
-          <div class="summary-card">
-            <h2 class="summary-title">2025 Summary</h2>
-            <div class="stats-list"></div>
+          <div class="stat-card">
+            <span class="stat-emoji">📚</span>
+            <p class="stat-value" id="stat-books">0</p>
+            <h2>Books</h2>
           </div>
           <div class="stat-card">
-            <h2>Total Books</h2>
-            <p class="stat-value" id="total-books">0</p>
+            <span class="stat-emoji">📄</span>
+            <p class="stat-value" id="stat-pages">0</p>
+            <h2>Pages</h2>
           </div>
           <div class="stat-card">
-            <h2>Average per Month</h2>
+            <span class="stat-emoji">📊</span>
+            <p class="stat-value" id="stat-avg-pages">0</p>
+            <h2>Avg Pages</h2>
+          </div>
+          <div class="stat-card">
+            <span class="stat-emoji">📅</span>
             <p class="stat-value" id="avg-per-month">0.0</p>
-          </div>
-          <div class="stat-card">
-            <h2>Total Pages</h2>
-            <p class="stat-value" id="total-pages">0</p>
+            <h2>Per Month</h2>
           </div>
         </section>
         <section id="chart-container"></section>
@@ -30,17 +34,13 @@ describe('Dashboard Layout Tests', () => {
   });
 
   // T002: Stats bar layout test
-  it('stats bar renders as horizontal flex row', () => {
+  it('stats bar renders as horizontal flex row with 4 stat cards', () => {
     const statsBar = document.querySelector('.stats-bar');
-    const summaryCard = document.querySelector('.summary-card');
     const statCards = document.querySelectorAll('.stat-card');
 
     expect(statsBar).toBeTruthy();
-    expect(summaryCard).toBeTruthy();
-    expect(statCards).toHaveLength(3);
+    expect(statCards).toHaveLength(4);
 
-    // All stat cards and summary card are direct children of stats-bar
-    expect(statsBar.contains(summaryCard)).toBe(true);
     statCards.forEach(card => {
       expect(statsBar.contains(card)).toBe(true);
     });
@@ -55,84 +55,34 @@ describe('Dashboard Layout Tests', () => {
     expect(bookListSection.parentElement).toBe(main);
   });
 
-  // T004: Summary card content test
-  it('summary card displays correct statistics', () => {
-    // Mock API response
-    const mockStats = {
-      year: 2025,
-      total_books: 42,
-      total_pages: 12450,
-      avg_pages_per_book: 296
-    };
+  // T004: Stat cards display correct values
+  it('stat cards display correct statistics when populated', () => {
+    document.getElementById('stat-books').textContent = '42';
+    document.getElementById('stat-pages').textContent = '12,450';
+    document.getElementById('stat-avg-pages').textContent = '296';
+    document.getElementById('avg-per-month').textContent = '3.5';
 
-    // Create summary card HTML
-    const summaryCard = document.querySelector('.summary-card');
-    summaryCard.innerHTML = `
-      <h2 class="summary-title">2025 Summary</h2>
-      <div class="stats-list">
-        <div class="stat-row">
-          <span class="stat-label">Total Books</span>
-          <span class="stat-value">42</span>
-        </div>
-        <div class="stat-row">
-          <span class="stat-label">Total Pages</span>
-          <span class="stat-value">12,450</span>
-        </div>
-        <div class="stat-row">
-          <span class="stat-label">Avg Pages/Book</span>
-          <span class="stat-value">296</span>
-        </div>
-      </div>
-    `;
-
-    // Assert card title
-    const title = summaryCard.querySelector('.summary-title');
-    expect(title.textContent).toBe('2025 Summary');
-
-    // Assert stat rows
-    const statRows = summaryCard.querySelectorAll('.stat-row');
-    expect(statRows).toHaveLength(3);
-
-    // Check Total Books
-    expect(statRows[0].querySelector('.stat-label').textContent).toBe('Total Books');
-    expect(statRows[0].querySelector('.stat-value').textContent).toBe('42');
-
-    // Check Total Pages (with comma separator)
-    expect(statRows[1].querySelector('.stat-label').textContent).toBe('Total Pages');
-    expect(statRows[1].querySelector('.stat-value').textContent).toBe('12,450');
-
-    // Check Avg Pages/Book
-    expect(statRows[2].querySelector('.stat-label').textContent).toBe('Avg Pages/Book');
-    expect(statRows[2].querySelector('.stat-value').textContent).toBe('296');
+    expect(document.getElementById('stat-books').textContent).toBe('42');
+    expect(document.getElementById('stat-pages').textContent).toBe('12,450');
+    expect(document.getElementById('stat-avg-pages').textContent).toBe('296');
+    expect(document.getElementById('avg-per-month').textContent).toBe('3.5');
   });
 
-  // T005: Empty state test
-  it('summary card shows empty state when no books', () => {
-    // Mock API response with 0 books
-    const mockStats = {
-      year: 2024,
-      total_books: 0,
-      total_pages: 0,
-      avg_pages_per_book: 0
-    };
+  // T005: Each stat card has an emoji
+  it('each stat card has an emoji icon', () => {
+    const emojis = document.querySelectorAll('.stat-emoji');
+    expect(emojis).toHaveLength(4);
+    expect(emojis[0].textContent).toBe('📚');
+    expect(emojis[1].textContent).toBe('📄');
+    expect(emojis[2].textContent).toBe('📊');
+    expect(emojis[3].textContent).toBe('📅');
+  });
 
-    // Create empty state HTML
-    const summaryCard = document.querySelector('.summary-card');
-    summaryCard.classList.add('empty-state');
-    summaryCard.innerHTML = `
-      <h2 class="summary-title">2024 Summary</h2>
-      <p class="empty-message">No books tracked for this year</p>
-    `;
-
-    // Assert empty state
-    const title = summaryCard.querySelector('.summary-title');
-    expect(title.textContent).toBe('2024 Summary');
-
-    const emptyMessage = summaryCard.querySelector('.empty-message');
-    expect(emptyMessage).toBeTruthy();
-    expect(emptyMessage.textContent).toContain('No books tracked');
-
-    // Ensure no error rendering
-    expect(summaryCard).toBeTruthy();
+  // T006: Empty state shows zeros
+  it('stat cards show zero values when no books', () => {
+    expect(document.getElementById('stat-books').textContent).toBe('0');
+    expect(document.getElementById('stat-pages').textContent).toBe('0');
+    expect(document.getElementById('stat-avg-pages').textContent).toBe('0');
+    expect(document.getElementById('avg-per-month').textContent).toBe('0.0');
   });
 });


### PR DESCRIPTION
## Summary

Replaces the single summary box with 4 individual stat cards, each with an emoji icon.

### Before
Single list-style summary box with rows for Total Books, Total Pages, Avg Pages/Book.

### After
```
[ 📚 34 ]  [ 📄 8,874 ]  [ 📊 261 ]  [ 📅 2.8 ]
  Books      Pages       Avg Pages    Per Month
```

### Changes
- **index.html** — replaced summary card with 4 individual stat cards
- **main.css** — removed summary card styles, updated stat card styles with emoji support, 2x2 grid on mobile
- **ui.js** — replaced `renderSummaryCard` with `renderStatCards`
- **main.js** — updated import/call
- **ui.test.js** — updated tests for new card structure (5 tests passing)

All frontend + backend tests pass ✅

Closes #43