### PR TITLE
fix: force stat cards into horizontal row

### DIFF
--- a/frontend/styles/main.css
+++ b/frontend/styles/main.css
@@ -102,13 +102,15 @@ main {
 /* Stats Bar - Horizontal Layout */
 .stats-bar {
     display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
     gap: 12px;
     margin-bottom: 16px;
     align-items: stretch;
 }
 
 .stats-bar .stat-card {
-    flex: 1;
+    flex: 1 1 0%;
     min-width: 0;
 }
 
@@ -417,7 +419,7 @@ main {
 
     .stats-bar .stat-card {
         flex: 1 1 calc(50% - 4px);
-        min-width: 0;
+        min-width: calc(50% - 4px);
     }
     
     .stat-card {


### PR DESCRIPTION
The stat cards were stacking vertically instead of sitting side-by-side. This explicitly sets `flex-direction: row` and `flex-wrap: nowrap` on `.stats-bar` to force horizontal layout on desktop. Wrapping only at mobile breakpoint (768px).