### PR TITLE
fix: update The Message shelf to read

### DIFF
--- a/books.json
+++ b/books.json
@@ -1100,8 +1100,8 @@
     "Date Read": "2025/10/18",
     "Date Added": "2024/11/29",
     "Bookshelves": "read",
-    "Bookshelves with positions": "to-read (#622)",
-    "Shelf": "to-read",
+    "Bookshelves with positions": "",
+    "Shelf": "read",
     "My Review": ""
   },
   {


### PR DESCRIPTION
The `Shelf` field for The Message was still `to-read` while `Bookshelves` was `read`, so it wasn't showing in the 2025 book list.